### PR TITLE
fix: JSON5 format of configs breaks the parsing

### DIFF
--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -8,9 +8,9 @@ class Util {
     }
 
     _stripJSONComments(data) {
-        var re = new RegExp("\/\/(.*)", "g");
         var commentEval = new RegExp(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm);
-        return data.replace(commentEval, '');
+        var commaEval = new RegExp(/,([\s\n]+[}\]])/gm);
+        return data.replace(commentEval, '').replace(commaEval, '$1');
     }
     _getRushVersion(filePath) {
         const rushJson = JSON.parse(


### PR DESCRIPTION
Generator fails if rush config files use other JSON5 features than just comments.

Comments are stripped from project's config json files, but JSON5 also supports trailing commas.
Suggested change isn't guaranteed to be safe tho, for example, if json file has string values with `,]`/`,}` sequences of chars in them (weird, but possible nonetheless).

Better approach would be to use an actual JSON5 parser (JSON5 supports way more things, that JSON doesn't), but i guess the intention here was to keep installation footprint minimal.